### PR TITLE
authn: add revised peer authenticator

### DIFF
--- a/extensions/authn/BUILD
+++ b/extensions/authn/BUILD
@@ -28,10 +28,12 @@ envoy_cc_library(
     name = "authenticator_essential_lib",
     srcs = [
         "authn_utils.cc",
+        "connection_context.cc",
         "filter_context.cc",
     ],
     hdrs = [
         "authn_utils.h",
+        "connection_context.h",
         "filter_context.h",
     ],
     repository = "@envoy",
@@ -62,6 +64,21 @@ envoy_cc_library(
     ],
 )
 
+envoy_cc_library(
+    name = "peer_authenticator_lib",
+    srcs = [
+        "peer_authenticator.cc",
+    ],
+    hdrs = [
+        "peer_authenticator.h",
+    ],
+    repository = "@envoy",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":authenticator_essential_lib",
+    ],
+)
+
 envoy_cc_test_library(
     name = "test_utils",
     hdrs = ["test_utils.h"],
@@ -77,6 +94,31 @@ envoy_cc_test(
     repository = "@envoy",
     deps = [
         ":request_authenticator_lib",
+        ":test_utils",
+        "@envoy//test/mocks/http:http_mocks",
+        "@envoy//test/test_common:utility_lib",
+    ],
+)
+
+envoy_cc_test(
+    name = "connection_context_test",
+    srcs = ["connection_context_test.cc"],
+    repository = "@envoy",
+    deps = [
+        ":request_authenticator_lib",
+        ":test_utils",
+        "@envoy//test/mocks/network:network_mocks",
+        "@envoy//test/mocks/ssl:ssl_mocks",
+        "@envoy//test/test_common:utility_lib",
+    ],
+)
+
+envoy_cc_test(
+    name = "peer_authenticator_test",
+    srcs = ["peer_authenticator_test.cc"],
+    repository = "@envoy",
+    deps = [
+        ":peer_authenticator_lib",
         ":test_utils",
         "@envoy//test/mocks/http:http_mocks",
         "@envoy//test/test_common:utility_lib",

--- a/extensions/authn/connection_context.cc
+++ b/extensions/authn/connection_context.cc
@@ -1,0 +1,111 @@
+/* Copyright 2020 Istio Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "extensions/authn/connection_context.h"
+
+#include "absl/strings/string_view.h"
+
+namespace Extensions {
+namespace AuthN {
+
+namespace {
+static constexpr absl::string_view kSpiffePrefix = "spiffe://";
+
+bool hasSpiffePrefix(const std::string& url) {
+  return url.find(kSpiffePrefix.data()) != std::string::npos;
+}
+}  // namespace
+
+ConnectionContextImpl::ConnectionContextImpl(const Connection* connection)
+    : connection_(connection) {}
+
+absl::optional<std::string> ConnectionContextImpl::trustDomain(bool peer) {
+  const auto cert_san = certSan(peer);
+  if (!cert_san.has_value() || !hasSpiffePrefix(cert_san.value())) {
+    return absl::nullopt;
+  }
+
+  // Skip the prefix "spiffe://" before getting trust domain.
+  auto slash = cert_san->find('/', kSpiffePrefix.size());
+  if (slash == std::string::npos) {
+    return absl::nullopt;
+  }
+
+  auto domain_len = slash - kSpiffePrefix.size();
+  return cert_san->substr(kSpiffePrefix.size(), domain_len);
+}
+
+absl::optional<std::string> ConnectionContextImpl::principalDomain(bool peer) {
+  const auto cert_san = certSan(peer);
+  if (cert_san.has_value()) {
+    if (hasSpiffePrefix(cert_san.value())) {
+      // Strip out the prefix "spiffe://" in the identity.
+      return cert_san->substr(kSpiffePrefix.size());
+    } else {
+      return cert_san;
+    }
+  }
+  return absl::nullopt;
+}
+
+bool ConnectionContextImpl::isMutualTls() const {
+  return connection_ != nullptr && connection_->ssl() != nullptr &&
+         connection_->ssl()->peerCertificatePresented();
+}
+
+absl::optional<uint32_t> ConnectionContextImpl::port() const {
+  if (!connection_) {
+    return absl::nullopt;
+  }
+  const auto local_address_instance = connection_->localAddress();
+  assert(local_address_instance != nullptr);
+  const auto ip = local_address_instance->ip();
+  if (!ip) {
+    return absl::nullopt;
+  }
+  return ip->port();
+}
+
+absl::optional<std::string> ConnectionContextImpl::certSan(bool peer) {
+  if (!connection_) {
+    return absl::nullopt;
+  }
+  const auto ssl = connection_->ssl();
+  if (!ssl) {
+    return absl::nullopt;
+  }
+  const auto& sans =
+      (peer ? ssl->uriSanPeerCertificate() : ssl->uriSanLocalCertificate());
+  if (sans.empty()) {
+    // empty result is not allowed.
+    return absl::nullopt;
+  }
+  std::string picked_san;
+  // return the first san with the 'spiffe://' prefix
+  for (const auto& san : sans) {
+    if (hasSpiffePrefix(san)) {
+      picked_san = san;
+      break;
+    }
+  }
+
+  if (picked_san.empty()) {
+    picked_san = sans[0];
+  }
+
+  return picked_san;
+}
+}  // namespace AuthN
+}  // namespace Extensions

--- a/extensions/authn/connection_context.h
+++ b/extensions/authn/connection_context.h
@@ -1,0 +1,70 @@
+/* Copyright 2020 Istio Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "absl/types/optional.h"
+#include "envoy/network/connection.h"
+
+namespace Extensions {
+namespace AuthN {
+
+using Envoy::Network::Connection;
+
+class ConnectionContext {
+ public:
+  virtual ~ConnectionContext() = default;
+
+  // Peer or local trust domain.
+  // It will return only `spiffe` prefixed domain.
+  virtual absl::optional<std::string> trustDomain(bool peer) PURE;
+
+  // Peer or local principal domain.
+  // It will return arbitary domain which will extracted from SAN.
+  virtual absl::optional<std::string> principalDomain(bool peer) PURE;
+
+  // Check whether established connection enabled mTLS or not.
+  virtual bool isMutualTls() const PURE;
+
+  // Connection port.
+  virtual absl::optional<uint32_t> port() const PURE;
+};
+
+class ConnectionContextImpl : public ConnectionContext {
+ public:
+  ConnectionContextImpl(const Connection* connection);
+
+  // ConnectionContext
+  absl::optional<std::string> trustDomain(bool peer) override;
+
+  absl::optional<std::string> principalDomain(bool peer) override;
+
+  bool isMutualTls() const override;
+
+  absl::optional<uint32_t> port() const override;
+
+ private:
+  // Get SAN from peer or local TLS certificate. It will return first `spiffe`
+  // prefixed SAN. If there is no `spiffe` prefixed SAN, it will return first
+  // SAN.
+  absl::optional<std::string> certSan(bool peer);
+
+  const Connection* connection_;
+};
+
+using ConnectionContextPtr = std::shared_ptr<ConnectionContext>;
+
+}  // namespace AuthN
+}  // namespace Extensions

--- a/extensions/authn/connection_context_test.cc
+++ b/extensions/authn/connection_context_test.cc
@@ -1,0 +1,153 @@
+/* Copyright 2020 Istio Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "extensions/authn/connection_context.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "test/mocks/network/mocks.h"
+#include "test/mocks/ssl/mocks.h"
+
+using testing::Return;
+using testing::ReturnRef;
+
+namespace Extensions {
+namespace AuthN {
+namespace {
+
+class ConnectionContextTest : public testing::Test {
+ public:
+  Envoy::Network::MockConnection connection_;
+  std::shared_ptr<Envoy::Ssl::MockConnectionInfo> ssl_conn_info_{
+      std::make_shared<Envoy::Ssl::MockConnectionInfo>()};
+  ConnectionContextImpl conn_context_{&connection_};
+};
+
+TEST_F(ConnectionContextTest, IsMutualTlsTest) {
+  EXPECT_CALL(connection_, ssl())
+      .Times(2)
+      .WillRepeatedly(Return(ssl_conn_info_));
+  EXPECT_CALL(*ssl_conn_info_, peerCertificatePresented())
+      .WillOnce(Return(true));
+  EXPECT_TRUE(conn_context_.isMutualTls());
+}
+
+TEST_F(ConnectionContextTest, TrustDomainTestWithoutSpiffePrefix) {
+  EXPECT_CALL(connection_, ssl()).WillOnce(Return(ssl_conn_info_));
+  EXPECT_CALL(*ssl_conn_info_, uriSanPeerCertificate())
+      .WillOnce(Return(std::vector<std::string>{"istio.io", "istio2.io"}));
+  EXPECT_FALSE(conn_context_.trustDomain(true).has_value());
+
+  EXPECT_CALL(connection_, ssl()).WillOnce(Return(ssl_conn_info_));
+  EXPECT_CALL(*ssl_conn_info_, uriSanLocalCertificate())
+      .WillOnce(Return(std::vector<std::string>{"istio.io", "istio2.io"}));
+  EXPECT_FALSE(conn_context_.trustDomain(false).has_value());
+}
+
+TEST_F(ConnectionContextTest, TrustDomainTestWithSpiffePrefix) {
+  EXPECT_CALL(connection_, ssl()).WillOnce(Return(ssl_conn_info_));
+  EXPECT_CALL(*ssl_conn_info_, uriSanPeerCertificate())
+      .WillOnce(
+          Return(std::vector<std::string>{"istio.io", "spiffe://istio2.io/"}));
+  EXPECT_EQ(conn_context_.trustDomain(true).value(), "istio2.io");
+
+  EXPECT_CALL(connection_, ssl()).WillOnce(Return(ssl_conn_info_));
+  EXPECT_CALL(*ssl_conn_info_, uriSanLocalCertificate())
+      .WillOnce(
+          Return(std::vector<std::string>{"istio.io", "spiffe://istio2.io/"}));
+  EXPECT_EQ(conn_context_.trustDomain(false).value(), "istio2.io");
+}
+
+TEST_F(ConnectionContextTest, TrustDomainTestWithInvalidSpiffePrefix) {
+  EXPECT_CALL(connection_, ssl()).WillOnce(Return(ssl_conn_info_));
+  EXPECT_CALL(*ssl_conn_info_, uriSanPeerCertificate())
+      .WillOnce(
+          Return(std::vector<std::string>{"istio.io", "spiffe:/istio2.io"}));
+  EXPECT_FALSE(conn_context_.trustDomain(true).has_value());
+
+  EXPECT_CALL(connection_, ssl()).WillOnce(Return(ssl_conn_info_));
+  EXPECT_CALL(*ssl_conn_info_, uriSanLocalCertificate())
+      .WillOnce(
+          Return(std::vector<std::string>{"istio.io", "spiffe:/istio2.io"}));
+  EXPECT_FALSE(conn_context_.trustDomain(false).has_value());
+}
+
+TEST_F(ConnectionContextTest, TrustDomainTestWithInvalidSpiffePrefixOnly) {
+  EXPECT_CALL(connection_, ssl()).WillOnce(Return(ssl_conn_info_));
+  EXPECT_CALL(*ssl_conn_info_, uriSanPeerCertificate())
+      .WillOnce(Return(std::vector<std::string>{"spiffe:/istio2.io"}));
+  EXPECT_FALSE(conn_context_.trustDomain(true).has_value());
+
+  EXPECT_CALL(connection_, ssl()).WillOnce(Return(ssl_conn_info_));
+  EXPECT_CALL(*ssl_conn_info_, uriSanLocalCertificate())
+      .WillOnce(Return(std::vector<std::string>{"spiffe:/istio2.io"}));
+  EXPECT_FALSE(conn_context_.trustDomain(false).has_value());
+}
+
+TEST_F(ConnectionContextTest, PrincipalDomainTestWithoutSpiffePrefix) {
+  EXPECT_CALL(connection_, ssl()).WillOnce(Return(ssl_conn_info_));
+  EXPECT_CALL(*ssl_conn_info_, uriSanPeerCertificate())
+      .WillOnce(Return(std::vector<std::string>{"istio.io", "istio2.io"}));
+  EXPECT_EQ(conn_context_.principalDomain(true).value(), "istio.io");
+
+  EXPECT_CALL(connection_, ssl()).WillOnce(Return(ssl_conn_info_));
+  EXPECT_CALL(*ssl_conn_info_, uriSanLocalCertificate())
+      .WillOnce(Return(std::vector<std::string>{"istio.io", "istio2.io"}));
+  EXPECT_EQ(conn_context_.principalDomain(false).value(), "istio.io");
+}
+
+TEST_F(ConnectionContextTest, PrincipalDomainTestWithSpiffePrefix) {
+  EXPECT_CALL(connection_, ssl()).WillOnce(Return(ssl_conn_info_));
+  EXPECT_CALL(*ssl_conn_info_, uriSanPeerCertificate())
+      .WillOnce(
+          Return(std::vector<std::string>{"istio.io", "spiffe://istio2.io/"}));
+  EXPECT_EQ(conn_context_.principalDomain(true).value(), "istio2.io/");
+
+  EXPECT_CALL(connection_, ssl()).WillOnce(Return(ssl_conn_info_));
+  EXPECT_CALL(*ssl_conn_info_, uriSanLocalCertificate())
+      .WillOnce(
+          Return(std::vector<std::string>{"istio.io", "spiffe://istio2.io/"}));
+  EXPECT_EQ(conn_context_.principalDomain(false).value(), "istio2.io/");
+}
+
+TEST_F(ConnectionContextTest, PrincipalDomainTestWithInvalidSpiffePrefix) {
+  EXPECT_CALL(connection_, ssl()).WillOnce(Return(ssl_conn_info_));
+  EXPECT_CALL(*ssl_conn_info_, uriSanPeerCertificate())
+      .WillOnce(
+          Return(std::vector<std::string>{"istio.io", "spiffe:/istio2.io"}));
+  EXPECT_EQ(conn_context_.principalDomain(true).value(), "istio.io");
+
+  EXPECT_CALL(connection_, ssl()).WillOnce(Return(ssl_conn_info_));
+  EXPECT_CALL(*ssl_conn_info_, uriSanLocalCertificate())
+      .WillOnce(
+          Return(std::vector<std::string>{"istio.io", "spiffe:/istio2.io"}));
+  EXPECT_EQ(conn_context_.principalDomain(false).value(), "istio.io");
+}
+
+TEST_F(ConnectionContextTest, PrincipalDomainTestWithInvalidSpiffePrefixOnly) {
+  EXPECT_CALL(connection_, ssl()).WillOnce(Return(ssl_conn_info_));
+  EXPECT_CALL(*ssl_conn_info_, uriSanPeerCertificate())
+      .WillOnce(Return(std::vector<std::string>{"spiffe:/istio2.io"}));
+  EXPECT_EQ(conn_context_.principalDomain(true).value(), "spiffe:/istio2.io");
+
+  EXPECT_CALL(connection_, ssl()).WillOnce(Return(ssl_conn_info_));
+  EXPECT_CALL(*ssl_conn_info_, uriSanLocalCertificate())
+      .WillOnce(Return(std::vector<std::string>{"spiffe:/istio2.io"}));
+  EXPECT_EQ(conn_context_.principalDomain(false).value(), "spiffe:/istio2.io");
+}
+
+}  // namespace
+}  // namespace AuthN
+}  // namespace Extensions

--- a/extensions/authn/filter_context.cc
+++ b/extensions/authn/filter_context.cc
@@ -30,12 +30,13 @@ using google::protobuf::util::MessageToJsonString;
 
 FilterContext::FilterContext(
     const envoy::config::core::v3::Metadata& dynamic_metadata,
-    const RequestHeaderMap& header_map, const Connection* connection,
+    const RequestHeaderMap& header_map,
+    const ConnectionContextPtr connection_context,
     const istio::envoy::config::filter::http::authn::v2alpha2::FilterConfig&
         filter_config)
     : dynamic_metadata_(dynamic_metadata),
       header_map_(header_map),
-      connection_(connection),
+      connection_context_(connection_context),
       filter_config_(filter_config) {}
 
 void FilterContext::setOriginResult(const Payload* payload) {
@@ -45,6 +46,12 @@ void FilterContext::setOriginResult(const Payload* payload) {
   // it's ok just to check jwt payload.
   if (payload != nullptr && payload->has_jwt()) {
     *result_.mutable_origin() = payload->jwt();
+  }
+}
+
+void FilterContext::setPeerAuthenticationResult(const Payload* payload) {
+  if (payload != nullptr && payload->has_x509()) {
+    result_.set_peer_user(payload->x509().user());
   }
 }
 

--- a/extensions/authn/filter_context.h
+++ b/extensions/authn/filter_context.h
@@ -18,6 +18,7 @@
 #include "envoy/config/core/v3/base.pb.h"
 #include "envoy/config/filter/http/authn/v2alpha2/config.pb.h"
 #include "envoy/network/connection.h"
+#include "extensions/authn/connection_context.h"
 #include "extensions/filters/http/well_known_names.h"
 #include "src/istio/authn/context.pb.h"
 
@@ -33,7 +34,8 @@ class FilterContext {
  public:
   FilterContext(
       const envoy::config::core::v3::Metadata& dynamic_metadata,
-      const RequestHeaderMap& header_map, const Connection* connection,
+      const RequestHeaderMap& header_map,
+      const ConnectionContextPtr connection_context,
       const istio::envoy::config::filter::http::authn::v2alpha2::FilterConfig&
           filter_config);
 
@@ -42,6 +44,10 @@ class FilterContext {
   // Sets origin result based on authenticated payload. Input payload can be
   // null, which basically changes nothing.
   void setOriginResult(const istio::authn::Payload* payload);
+
+  // Sets peer authentication result based on authenticated payload. Input
+  // payload can be null, which basically changes nothing.
+  void setPeerAuthenticationResult(const istio::authn::Payload* payload);
 
   // Gets JWT payload (output from JWT filter) for given issuer. If non-empty
   // payload found, returns true and set the output payload string. Otherwise,
@@ -52,7 +58,7 @@ class FilterContext {
   const istio::authn::Result& authenticationResult() { return result_; }
 
   // Accessor to connection
-  const Connection* connection() { return connection_; }
+  const ConnectionContextPtr connectionContext() { return connection_context_; }
 
   const RequestHeaderMap& headerMap() const { return header_map_; }
 
@@ -80,8 +86,8 @@ class FilterContext {
   // that could be used to decide if a JWT should be used for validation.
   const RequestHeaderMap& header_map_;
 
-  // Pointer to network connection of the request.
-  const Connection* connection_;
+  // Connection context
+  const ConnectionContextPtr connection_context_;
 
   // Holds authentication attribute outputs.
   istio::authn::Result result_;

--- a/extensions/authn/peer_authenticator.cc
+++ b/extensions/authn/peer_authenticator.cc
@@ -1,0 +1,103 @@
+/* Copyright 2020 Istio Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "extensions/authn/peer_authenticator.h"
+
+namespace Extensions {
+namespace AuthN {
+
+PeerAuthenticatorImpl::PeerAuthenticatorImpl(
+    FilterContextPtr filter_context,
+    const istio::security::v1beta1::PeerAuthentication& policy)
+    : peer_authentication_policy_(policy), filter_context_(filter_context) {}
+
+bool PeerAuthenticatorImpl::validateX509(
+    istio::authn::X509Payload* payload,
+    const istio::security::v1beta1::PeerAuthentication::MutualTLS&
+        mtls_policy) {
+  if (mtls_policy.mode() ==
+      istio::security::v1beta1::PeerAuthentication::MutualTLS::DISABLE) {
+    return true;
+  }
+
+  const auto principal_domain =
+      filter_context_->connectionContext()->principalDomain(true);
+  const bool has_user = filter_context_->connectionContext()->isMutualTls() &&
+                        principal_domain.has_value();
+
+  if (!has_user) {
+    switch (mtls_policy.mode()) {
+      case istio::security::v1beta1::PeerAuthentication::MutualTLS::UNSET:
+      case istio::security::v1beta1::PeerAuthentication::MutualTLS::PERMISSIVE:
+        return true;
+      case istio::security::v1beta1::PeerAuthentication::MutualTLS::STRICT:
+        return false;
+      default:
+        NOT_REACHED_GCOVR_EXCL_LINE;
+    }
+  }
+
+  payload->set_user(principal_domain.value());
+
+  return validateTrustDomain();
+}
+
+bool PeerAuthenticatorImpl::run(istio::authn::Payload* payload) {
+  const auto local_port = filter_context_->connectionContext()->port();
+  const auto port_level_mtls = peer_authentication_policy_.port_level_mtls();
+
+  if (local_port.has_value()) {
+    const auto mtls_policy = port_level_mtls.find(local_port.value());
+    if (mtls_policy != port_level_mtls.end()) {
+      if (validateX509(payload->mutable_x509(), mtls_policy->second)) {
+        filter_context_->setPeerAuthenticationResult(payload);
+        return true;
+      }
+
+      return false;
+    }
+  }
+
+  if (validateX509(payload->mutable_x509(),
+                   peer_authentication_policy_.mtls())) {
+    filter_context_->setPeerAuthenticationResult(payload);
+    return true;
+  }
+
+  return false;
+}
+
+bool PeerAuthenticatorImpl::validateTrustDomain() {
+  const auto peer_trust_domain =
+      filter_context_->connectionContext()->trustDomain(true);
+  if (!peer_trust_domain.has_value()) {
+    return false;
+  }
+
+  const auto local_trust_domain =
+      filter_context_->connectionContext()->trustDomain(false);
+  if (!local_trust_domain.has_value()) {
+    return false;
+  }
+
+  if (peer_trust_domain.value() != local_trust_domain.value()) {
+    return false;
+  }
+
+  return true;
+}
+
+}  // namespace AuthN
+}  // namespace Extensions

--- a/extensions/authn/peer_authenticator.h
+++ b/extensions/authn/peer_authenticator.h
@@ -1,0 +1,70 @@
+/* Copyright 2020 Istio Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "extensions/authn/authn_utils.h"
+#include "extensions/authn/connection_context.h"
+#include "extensions/authn/filter_context.h"
+#include "security/v1beta1/peer_authentication.pb.h"
+#include "src/istio/authn/context.pb.h"
+
+namespace Extensions {
+namespace AuthN {
+
+class PeerAuthenticator {
+ public:
+  virtual ~PeerAuthenticator() = default;
+
+  // Validate TLS/MTLS connection and extract authenticated attributes (just
+  // source user identity for now). Unlike mTLS, TLS connection does not require
+  // a client certificate..
+  virtual bool validateX509(
+      istio::authn::X509Payload* payload,
+      const istio::security::v1beta1::PeerAuthentication::MutualTLS&
+          mtls_policy) PURE;
+};
+
+// PeerAuthenticator performs mTLS authentication for given credential
+// rule.
+class PeerAuthenticatorImpl : public PeerAuthenticator {
+ public:
+  PeerAuthenticatorImpl(
+      FilterContextPtr filter_context,
+      const istio::security::v1beta1::PeerAuthentication& policy);
+
+  // IRequestAuthenticator
+  bool validateX509(
+      istio::authn::X509Payload* payload,
+      const istio::security::v1beta1::PeerAuthentication::MutualTLS&
+          mtls_policy) override;
+
+  // Perform authentication.
+  bool run(istio::authn::Payload* payload);
+
+ private:
+  bool validateTrustDomain();
+
+  // Reference to the authentication policy that the authenticator should
+  // enforce. Typically, the actual object is owned by filter.
+  const istio::security::v1beta1::PeerAuthentication
+      peer_authentication_policy_;
+
+  // Pointer to filter state. Do not own.
+  FilterContextPtr filter_context_;
+};
+
+}  // namespace AuthN
+}  // namespace Extensions

--- a/extensions/authn/peer_authenticator_test.cc
+++ b/extensions/authn/peer_authenticator_test.cc
@@ -1,0 +1,291 @@
+/* Copyright 2020 Istio Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "extensions/authn/peer_authenticator.h"
+
+#include "extensions/authn/test_utils.h"
+#include "gtest/gtest.h"
+#include "test/test_common/utility.h"
+
+using ::google::protobuf::util::MessageDifferencer;
+using testing::Invoke;
+using testing::Return;
+
+namespace Extensions {
+namespace AuthN {
+namespace {
+
+namespace {
+using istio::security::v1beta1::PeerAuthentication;
+
+static PeerAuthentication::MutualTLS::Mode disable =
+    PeerAuthentication::MutualTLS::DISABLE;
+static PeerAuthentication::MutualTLS::Mode strict =
+    PeerAuthentication::MutualTLS::STRICT;
+static PeerAuthentication::MutualTLS::Mode permissive =
+    PeerAuthentication::MutualTLS::PERMISSIVE;
+}  // namespace
+
+class MockConnectionContext : public ConnectionContext {
+ public:
+  MOCK_METHOD(absl::optional<std::string>, trustDomain, (bool));
+  MOCK_METHOD(absl::optional<std::string>, principalDomain, (bool));
+  MOCK_METHOD(bool, isMutualTls, (), (const));
+  MOCK_METHOD(absl::optional<uint32_t>, port, (), (const));
+};
+
+class ValidateX509Test : public testing::Test {
+ public:
+  void setMtlsMode(
+      istio::security::v1beta1::PeerAuthentication::MutualTLS::Mode mode) {
+    peer_authentication_policy_.mutable_mtls()->set_mode(mode);
+  }
+
+  void initialize() {
+    filter_context_.reset();
+    filter_context_ = std::make_unique<FilterContext>(
+        envoy::config::core::v3::Metadata::default_instance(),
+        Envoy::Http::TestRequestHeaderMapImpl(), connection_context_,
+        istio::envoy::config::filter::http::authn::v2alpha2::FilterConfig::
+            default_instance());
+
+    authenticator_.reset();
+    authenticator_ = std::make_unique<PeerAuthenticatorImpl>(
+        filter_context_, peer_authentication_policy_);
+  }
+
+ protected:
+  std::unique_ptr<PeerAuthenticatorImpl> authenticator_;
+  FilterContextPtr filter_context_;
+  istio::security::v1beta1::PeerAuthentication peer_authentication_policy_;
+  istio::authn::X509Payload result_payload_;
+  std::shared_ptr<MockConnectionContext> connection_context_{
+      std::make_shared<MockConnectionContext>()};
+};
+
+TEST_F(ValidateX509Test, EmptyPolicy) {
+  initialize();
+
+  // When there is no specified policy. It will be choiced UNSET as MutualTLS
+  // policy. It will behave as if PERMISSIVE was specified.
+  EXPECT_CALL(*connection_context_, principalDomain(true))
+      .WillOnce(Return(absl::nullopt));
+  EXPECT_CALL(*connection_context_, isMutualTls()).WillOnce(Return(true));
+  EXPECT_TRUE(authenticator_->validateX509(&result_payload_,
+                                           peer_authentication_policy_.mtls()));
+}
+
+TEST_F(ValidateX509Test, DisabledMutualTls) {
+  setMtlsMode(disable);
+  initialize();
+  EXPECT_TRUE(authenticator_->validateX509(&result_payload_,
+                                           peer_authentication_policy_.mtls()));
+}
+
+TEST_F(ValidateX509Test, NoUserStrictMutualTls) {
+  setMtlsMode(strict);
+  initialize();
+
+  EXPECT_CALL(*connection_context_, principalDomain(true))
+      .WillOnce(Return(absl::nullopt));
+  EXPECT_CALL(*connection_context_, isMutualTls()).WillOnce(Return(true));
+  EXPECT_FALSE(authenticator_->validateX509(
+      &result_payload_, peer_authentication_policy_.mtls()));
+}
+
+TEST_F(ValidateX509Test, MutualTlsWithPeerUser) {
+  setMtlsMode(strict);
+  initialize();
+
+  EXPECT_CALL(*connection_context_, principalDomain(true))
+      .WillOnce(Return("istio.io"));
+  EXPECT_CALL(*connection_context_, isMutualTls()).WillOnce(Return(true));
+
+  // Has same trust domain between peer and local.
+  EXPECT_CALL(*connection_context_, trustDomain(true))
+      .WillOnce(Return("istio2.io"));
+  EXPECT_CALL(*connection_context_, trustDomain(false))
+      .WillOnce(Return("istio2.io"));
+
+  EXPECT_TRUE(authenticator_->validateX509(&result_payload_,
+                                           peer_authentication_policy_.mtls()));
+  EXPECT_EQ("istio.io", result_payload_.user());
+
+  // Permissive mode with peer user
+  setMtlsMode(permissive);
+  initialize();
+
+  EXPECT_CALL(*connection_context_, principalDomain(true))
+      .WillOnce(Return("istio.io"));
+  EXPECT_CALL(*connection_context_, isMutualTls()).WillOnce(Return(true));
+
+  // Has different trust domain between peer and local.
+  EXPECT_CALL(*connection_context_, trustDomain(true))
+      .WillOnce(Return("istio2.io"));
+  EXPECT_CALL(*connection_context_, trustDomain(false))
+      .WillOnce(Return("istio3.io"));
+
+  EXPECT_FALSE(authenticator_->validateX509(
+      &result_payload_, peer_authentication_policy_.mtls()));
+  EXPECT_EQ("istio.io", result_payload_.user());
+}
+
+TEST_F(ValidateX509Test, NoUserPermissiveMutualTls) {
+  setMtlsMode(permissive);
+  initialize();
+
+  EXPECT_CALL(*connection_context_, principalDomain(true))
+      .WillOnce(Return(absl::nullopt));
+  EXPECT_CALL(*connection_context_, isMutualTls()).WillOnce(Return(true));
+  EXPECT_TRUE(authenticator_->validateX509(&result_payload_,
+                                           peer_authentication_policy_.mtls()));
+}
+
+class MockPeerAuthenticator : public PeerAuthenticatorImpl {
+ public:
+  MockPeerAuthenticator(
+      FilterContextPtr filter_context,
+      const istio::security::v1beta1::PeerAuthentication& policy)
+      : PeerAuthenticatorImpl(filter_context, policy) {}
+
+  MOCK_METHOD(bool, validateX509,
+              (istio::authn::X509Payload * payload,
+               const istio::security::v1beta1::PeerAuthentication::MutualTLS&
+                   mtls_policy));
+};
+
+class PeerAuthenticatorTest : public testing::Test {
+ public:
+  void initialize() {
+    filter_context_.reset();
+    filter_context_ = std::make_unique<FilterContext>(
+        envoy::config::core::v3::Metadata::default_instance(),
+        Envoy::Http::TestRequestHeaderMapImpl(), connection_context_,
+        istio::envoy::config::filter::http::authn::v2alpha2::FilterConfig::
+            default_instance());
+
+    authenticator_.reset();
+    authenticator_ = std::make_unique<MockPeerAuthenticator>(
+        filter_context_, peer_authentication_policy_);
+  }
+
+  void setMtlsMode(
+      istio::security::v1beta1::PeerAuthentication::MutualTLS::Mode mode) {
+    peer_authentication_policy_.mutable_mtls()->set_mode(mode);
+  }
+
+  void setPortLevalMtls(
+      uint32_t port,
+      istio::security::v1beta1::PeerAuthentication::MutualTLS::Mode mode) {
+    istio::security::v1beta1::PeerAuthentication::MutualTLS mtls_config;
+    mtls_config.set_mode(mode);
+    (*peer_authentication_policy_.mutable_port_level_mtls())[port] =
+        mtls_config;
+  }
+
+ protected:
+  std::unique_ptr<MockPeerAuthenticator> authenticator_;
+  istio::authn::Payload result_payload_;
+
+  FilterContextPtr filter_context_;
+  istio::security::v1beta1::PeerAuthentication peer_authentication_policy_;
+  std::shared_ptr<MockConnectionContext> connection_context_{
+      std::make_shared<MockConnectionContext>()};
+};
+
+TEST_F(PeerAuthenticatorTest, EmptyPolicy) {
+  initialize();
+  EXPECT_CALL(*connection_context_, port()).WillOnce(Return(5000));
+  EXPECT_CALL(*authenticator_, validateX509(_, _)).WillOnce(Return(false));
+
+  EXPECT_FALSE(authenticator_->run(&result_payload_));
+}
+
+TEST_F(PeerAuthenticatorTest, NoPortLevelPolicy) {
+  initialize();
+
+  EXPECT_CALL(*connection_context_, port()).WillOnce(Return(5000));
+  EXPECT_CALL(*authenticator_, validateX509(result_payload_.mutable_x509(), _))
+      .WillOnce(Invoke(
+          [](istio::authn::X509Payload* payload,
+             const istio::security::v1beta1::PeerAuthentication::MutualTLS&) {
+            payload->set_user("foo");
+            return true;
+          }));
+
+  EXPECT_TRUE(authenticator_->run(&result_payload_));
+  EXPECT_EQ("foo", filter_context_->authenticationResult().peer_user());
+}
+
+MATCHER_P(MtlsPolicyEq, rhs, "") { return arg.mode() == rhs.mode(); }
+
+TEST_F(PeerAuthenticatorTest, BasicPortLevelPolicyTest) {
+  setPortLevalMtls(5000, strict);
+  initialize();
+
+  EXPECT_CALL(*connection_context_, port()).WillOnce(Return(5000));
+  EXPECT_CALL(
+      *authenticator_,
+      validateX509(
+          result_payload_.mutable_x509(),
+          MtlsPolicyEq(peer_authentication_policy_.port_level_mtls().at(5000))))
+      .WillOnce(Invoke(
+          [](istio::authn::X509Payload* payload,
+             const istio::security::v1beta1::PeerAuthentication::MutualTLS&) {
+            payload->set_user("foo");
+            return true;
+          }));
+
+  EXPECT_TRUE(authenticator_->run(&result_payload_));
+  EXPECT_EQ("foo", filter_context_->authenticationResult().peer_user());
+}
+
+TEST_F(PeerAuthenticatorTest, PortLevelPeerAuthenticationFailed) {
+  setPortLevalMtls(5000, strict);
+  initialize();
+
+  EXPECT_CALL(*connection_context_, port()).WillOnce(Return(5000));
+  EXPECT_CALL(
+      *authenticator_,
+      validateX509(
+          result_payload_.mutable_x509(),
+          MtlsPolicyEq(peer_authentication_policy_.port_level_mtls().at(5000))))
+      .WillOnce(Return(false));
+
+  EXPECT_FALSE(authenticator_->run(&result_payload_));
+}
+
+TEST_F(PeerAuthenticatorTest, PortLevelPeerAuthenticationNotFound) {
+  setPortLevalMtls(8000, strict);
+  initialize();
+
+  EXPECT_CALL(*connection_context_, port()).WillOnce(Return(5000));
+  EXPECT_CALL(*authenticator_,
+              validateX509(result_payload_.mutable_x509(),
+                           MtlsPolicyEq(peer_authentication_policy_.mtls())))
+      .WillOnce(Invoke(
+          [](istio::authn::X509Payload* payload,
+             const istio::security::v1beta1::PeerAuthentication::MutualTLS&) {
+            payload->set_user("foo");
+            return true;
+          }));
+
+  EXPECT_TRUE(authenticator_->run(&result_payload_));
+  EXPECT_EQ("foo", filter_context_->authenticationResult().peer_user());
+}
+
+}  // namespace
+}  // namespace AuthN
+}  // namespace Extensions


### PR DESCRIPTION
This is a part of replacement of authn wasm implementation. It is using revised peer authentication API. istio/api#1536
#2800 is too large and hard to review all codes so that I split all of authn wasm implementation.